### PR TITLE
SP 用のスタイルを設定

### DIFF
--- a/.angular-cli.json
+++ b/.angular-cli.json
@@ -18,6 +18,11 @@
       "tsconfig": "tsconfig.app.json",
       "testTsconfig": "tsconfig.spec.json",
       "prefix": "app",
+      "stylePreprocessorOptions": {
+        "includePaths": [
+          "assets/styles"
+        ]
+      },
       "styles": [
         "styles.scss"
       ],

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,3 +1,5 @@
+@import '../assets/styles/mixin';
+
 .header {
   display: flex;
   width: 100%;
@@ -9,7 +11,7 @@
     font-size: 1.5rem;
     color: white;
     padding-left: 16px;
-    @media only screen and (max-width: 480px) {
+    @include sp-display() {
       font-size: 1.2rem;
     }
   }

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -9,5 +9,8 @@
     font-size: 1.5rem;
     color: white;
     padding-left: 16px;
+    @media only screen and (max-width: 480px) {
+      font-size: 1.2rem;
+    }
   }
 }

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,4 +1,4 @@
-@import '../assets/styles/mixin';
+@import 'mixin';
 
 .header {
   display: flex;

--- a/src/assets/styles/_mixin.scss
+++ b/src/assets/styles/_mixin.scss
@@ -1,0 +1,3 @@
+@mixin sp-display() {
+  @media only screen and (max-width: 480px) { @content; }
+}


### PR DESCRIPTION
## 対応内容
* include path を config に定義し、パス無しで css を import できるように変更
* mixin を用意し sp 用のスタイルを定義しやすく変更
* logo の sp スタイルを設定

## 参考
* https://qiita.com/kyaido/items/828906ffa7198e99d0b7
* https://github.com/angular/angular-cli/wiki/stories-global-styles