### PR TITLE
spyOn を使用してサービスメソッドの返り値をテストダブルで差し替え

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed, async } from '@angular/core/testing';
+import { of } from 'rxjs/observable/of';
 import { AppComponent } from './app.component';
 import { TimerComponent } from './timer/timer.component';
 import { TimerService } from './timer.service';
@@ -9,7 +10,7 @@ describe('AppComponent', () => {
         AppComponent,
         TimerComponent
       ],
-      providers: [TimerService],
+      providers: [ { provide: TimerService, useValue: { countSecond: () => {} } } ],
     }).compileComponents();
   }));
   it('should create the app', async(() => {
@@ -22,11 +23,14 @@ describe('AppComponent', () => {
     const app = fixture.debugElement.componentInstance;
     expect(app.title).toEqual('Pandora');
   }));
-  // FIXME: https://github.com/kasaharu/Pandora/issues/14
-  // it('should render title in a header tag', async(() => {
-  //   const fixture = TestBed.createComponent(AppComponent);
-  //   fixture.detectChanges();
-  //   const compiled = fixture.debugElement.nativeElement;
-  //   expect(compiled.querySelector('header').textContent).toContain('Pandora');
-  // }));
+  it('should render title in a header tag', async(() => {
+    const timerService = TestBed.get(TimerService);
+    spyOn(timerService, 'countSecond')
+      .and.returnValue(of(1));
+
+    const fixture = TestBed.createComponent(AppComponent);
+    fixture.detectChanges();
+    const compiled = fixture.debugElement.nativeElement;
+    expect(compiled.querySelector('header').textContent).toContain('Pandora');
+  }));
 });


### PR DESCRIPTION
**問題**

* Observable を返すサービスクラスのメソッドが呼ばれるとテストが timeout して失敗していた
    * ref. #14 

**対応内容**

* `spyOn()` を使用してメソッドをテストダブルに変更

